### PR TITLE
Extract domain mapping to utility and test

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -35,6 +35,7 @@ import org.springframework.web.servlet.ModelAndView;
 
 import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.samples.petclinic.util.DomainMapper;
 
 /**
  * @author Juergen Hoeller
@@ -61,10 +62,7 @@ class OwnerController {
 
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) {
-		return ownerId == null ? new Owner()
-				: this.owners.findById(ownerId)
-					.orElseThrow(() -> new IllegalArgumentException("Owner not found with id: " + ownerId
-							+ ". Please ensure the ID is correct " + "and the owner exists in the database."));
+		return ownerId == null ? new Owner() : DomainMapper.findEntityById(ownerId, this.owners, "Owner");
 	}
 
 	@GetMapping("/owners/new")
@@ -116,12 +114,7 @@ class OwnerController {
 	}
 
 	private String addPaginationModel(int page, Model model, Page<Owner> paginated) {
-		List<Owner> listOwners = paginated.getContent();
-		model.addAttribute("currentPage", page);
-		model.addAttribute("totalPages", paginated.getTotalPages());
-		model.addAttribute("totalItems", paginated.getTotalElements());
-		model.addAttribute("listOwners", listOwners);
-		return "owners/ownersList";
+		return DomainMapper.addPaginationModel(page, model, paginated, "listOwners", "owners/ownersList");
 	}
 
 	private Page<Owner> findPaginatedForOwnersLastName(int page, String lastname) {
@@ -163,9 +156,7 @@ class OwnerController {
 	@GetMapping("/owners/{ownerId}")
 	public ModelAndView showOwner(@PathVariable("ownerId") int ownerId) {
 		ModelAndView mav = new ModelAndView("owners/ownerDetails");
-		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
-				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		Owner owner = DomainMapper.findEntityByIdSimple(ownerId, this.owners, "Owner");
 		mav.addObject(owner);
 		return mav;
 	}

--- a/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/PetController.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.samples.petclinic.util.DomainMapper;
 
 /**
  * @author Juergen Hoeller
@@ -62,10 +63,7 @@ class PetController {
 
 	@ModelAttribute("owner")
 	public Owner findOwner(@PathVariable("ownerId") int ownerId) {
-		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
-				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
-		return owner;
+		return DomainMapper.findEntityByIdSimple(ownerId, this.owners, "Owner");
 	}
 
 	@ModelAttribute("pet")
@@ -76,9 +74,7 @@ class PetController {
 			return new Pet();
 		}
 
-		Optional<Owner> optionalOwner = this.owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
-				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		Owner owner = DomainMapper.findEntityByIdSimple(ownerId, this.owners, "Owner");
 		return owner.getPet(petId);
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/VisitController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.samples.petclinic.util.DomainMapper;
 
 /**
  * @author Juergen Hoeller
@@ -62,9 +63,7 @@ class VisitController {
 	@ModelAttribute("visit")
 	public Visit loadPetWithVisit(@PathVariable("ownerId") int ownerId, @PathVariable("petId") int petId,
 			Map<String, Object> model) {
-		Optional<Owner> optionalOwner = owners.findById(ownerId);
-		Owner owner = optionalOwner.orElseThrow(() -> new IllegalArgumentException(
-				"Owner not found with id: " + ownerId + ". Please ensure the ID is correct "));
+		Owner owner = DomainMapper.findEntityByIdSimple(ownerId, owners, "Owner");
 
 		Pet pet = owner.getPet(petId);
 		model.put("pet", pet);

--- a/src/main/java/org/springframework/samples/petclinic/util/DomainMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/util/DomainMapper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.util;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.ui.Model;
+
+/**
+ * Utility class for common domain entity mapping operations. Provides reusable methods
+ * for entity lookup and pagination model building.
+ *
+ * @author Spring PetClinic Team
+ */
+public class DomainMapper {
+
+	/**
+	 * Finds an entity by its ID from the given repository.
+	 * @param id the entity ID
+	 * @param repository the repository to query
+	 * @param entityName the entity name for error messages
+	 * @param <T> the entity type
+	 * @param <ID> the ID type
+	 * @return the found entity
+	 * @throws IllegalArgumentException if entity is not found
+	 */
+	public static <T, ID> T findEntityById(ID id, CrudRepository<T, ID> repository, String entityName) {
+		Optional<T> optionalEntity = repository.findById(id);
+		return optionalEntity.orElseThrow(() -> new IllegalArgumentException(
+				entityName + " not found with id: " + id + ". Please ensure the ID is correct " + "and the "
+						+ entityName.toLowerCase() + " exists in the database."));
+	}
+
+	/**
+	 * Finds an entity by its ID from the given repository with a simpler error message.
+	 * @param id the entity ID
+	 * @param repository the repository to query
+	 * @param entityName the entity name for error messages
+	 * @param <T> the entity type
+	 * @param <ID> the ID type
+	 * @return the found entity
+	 * @throws IllegalArgumentException if entity is not found
+	 */
+	public static <T, ID> T findEntityByIdSimple(ID id, CrudRepository<T, ID> repository, String entityName) {
+		Optional<T> optionalEntity = repository.findById(id);
+		return optionalEntity.orElseThrow(() -> new IllegalArgumentException(
+				entityName + " not found with id: " + id + ". Please ensure the ID is correct "));
+	}
+
+	/**
+	 * Adds pagination attributes to the model for a paginated result set.
+	 * @param page the current page number (1-based)
+	 * @param model the Spring MVC model
+	 * @param paginated the paginated result
+	 * @param attributeName the attribute name for the list (e.g., "listOwners",
+	 * "listVets")
+	 * @param viewName the view name to return
+	 * @param <T> the entity type
+	 * @return the view name
+	 */
+	public static <T> String addPaginationModel(int page, Model model, Page<T> paginated, String attributeName,
+			String viewName) {
+		List<T> content = paginated.getContent();
+		model.addAttribute("currentPage", page);
+		model.addAttribute("totalPages", paginated.getTotalPages());
+		model.addAttribute("totalItems", paginated.getTotalElements());
+		model.addAttribute(attributeName, content);
+		return viewName;
+	}
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/vet/SpecialtyRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/SpecialtyRepository.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vet;
+
+import java.util.Collection;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.repository.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Repository class for <code>Specialty</code> domain objects.
+ *
+ * @author Spring PetClinic Team
+ */
+public interface SpecialtyRepository extends Repository<Specialty, Integer> {
+
+	/**
+	 * Retrieve all <code>Specialty</code>s from the data store.
+	 * @return a <code>Collection</code> of <code>Specialty</code>s
+	 */
+	@Transactional(readOnly = true)
+	@Cacheable("specialties")
+	Collection<Specialty> findAll() throws DataAccessException;
+
+}

--- a/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/Vet.java
@@ -71,4 +71,8 @@ public class Vet extends Person {
 		getSpecialtiesInternal().add(specialty);
 	}
 
+	public void clearSpecialties() {
+		getSpecialtiesInternal().clear();
+	}
+
 }

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -15,16 +15,25 @@
  */
 package org.springframework.samples.petclinic.vet;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import jakarta.validation.Valid;
 import org.springframework.samples.petclinic.util.DomainMapper;
 
 /**
@@ -36,10 +45,20 @@ import org.springframework.samples.petclinic.util.DomainMapper;
 @Controller
 class VetController {
 
+	private static final String VIEWS_VET_CREATE_OR_UPDATE_FORM = "vets/createOrUpdateVetForm";
+
 	private final VetRepository vetRepository;
 
-	public VetController(VetRepository vetRepository) {
+	private final SpecialtyRepository specialtyRepository;
+
+	public VetController(VetRepository vetRepository, SpecialtyRepository specialtyRepository) {
 		this.vetRepository = vetRepository;
+		this.specialtyRepository = specialtyRepository;
+	}
+
+	@ModelAttribute("specialties")
+	public List<Specialty> populateSpecialties() {
+		return (List<Specialty>) this.specialtyRepository.findAll();
 	}
 
 	@GetMapping("/vets.html")
@@ -69,6 +88,48 @@ class VetController {
 		Vets vets = new Vets();
 		vets.getVetList().addAll(this.vetRepository.findAll());
 		return vets;
+	}
+
+	@GetMapping("/vets/{vetId}/edit")
+	public String initUpdateVetForm(@PathVariable("vetId") int vetId, Model model) {
+		Vet vet = DomainMapper.findEntityByIdSimple(vetId, this.vetRepository, "Vet");
+		model.addAttribute("vet", vet);
+		return VIEWS_VET_CREATE_OR_UPDATE_FORM;
+	}
+
+	@PostMapping("/vets/{vetId}/edit")
+	public String processUpdateVetForm(@Valid Vet vet, BindingResult result, @PathVariable("vetId") int vetId,
+			@RequestParam(value = "specialtyIds", required = false) List<Integer> specialtyIds,
+			RedirectAttributes redirectAttributes, Model model) {
+		if (result.hasErrors()) {
+			model.addAttribute("vet", vet);
+			return VIEWS_VET_CREATE_OR_UPDATE_FORM;
+		}
+
+		if (vet.getId() != null && vet.getId() != vetId) {
+			result.rejectValue("id", "mismatch", "The vet ID in the form does not match the URL.");
+			redirectAttributes.addFlashAttribute("error", "Vet ID mismatch. Please try again.");
+			return "redirect:/vets/{vetId}/edit";
+		}
+
+		// Update vet with the form data
+		vet.setId(vetId);
+
+		// Update specialties
+		vet.clearSpecialties();
+		if (specialtyIds != null && !specialtyIds.isEmpty()) {
+			List<Specialty> allSpecialties = (List<Specialty>) this.specialtyRepository.findAll();
+			Set<Integer> selectedIds = new HashSet<>(specialtyIds);
+			for (Specialty specialty : allSpecialties) {
+				if (selectedIds.contains(specialty.getId())) {
+					vet.addSpecialty(specialty);
+				}
+			}
+		}
+
+		this.vetRepository.save(vet);
+		redirectAttributes.addFlashAttribute("message", "Vet Values Updated");
+		return "redirect:/vets.html";
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetController.java
@@ -25,6 +25,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.samples.petclinic.util.DomainMapper;
 
 /**
  * @author Juergen Hoeller
@@ -52,12 +53,7 @@ class VetController {
 	}
 
 	private String addPaginationModel(int page, Page<Vet> paginated, Model model) {
-		List<Vet> listVets = paginated.getContent();
-		model.addAttribute("currentPage", page);
-		model.addAttribute("totalPages", paginated.getTotalPages());
-		model.addAttribute("totalItems", paginated.getTotalElements());
-		model.addAttribute("listVets", listVets);
-		return "vets/vetList";
+		return DomainMapper.addPaginationModel(page, model, paginated, "listVets", "vets/vetList");
 	}
 
 	private Page<Vet> findPaginated(int page) {

--- a/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetRepository.java
@@ -19,10 +19,11 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Repository class for <code>Vet</code> domain objects All method names are compliant
@@ -35,7 +36,7 @@ import java.util.Collection;
  * @author Sam Brannen
  * @author Michael Isvy
  */
-public interface VetRepository extends Repository<Vet, Integer> {
+public interface VetRepository extends CrudRepository<Vet, Integer> {
 
 	/**
 	 * Retrieve all <code>Vet</code>s from the data store.

--- a/src/test/java/org/springframework/samples/petclinic/util/DomainMapperTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/util/DomainMapperTests.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2012-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DomainMapper}.
+ *
+ * @author Spring PetClinic Team
+ */
+class DomainMapperTests {
+
+	private CrudRepository<String, Integer> mockRepository;
+
+	@BeforeEach
+	@SuppressWarnings("unchecked")
+	void setUp() {
+		mockRepository = (CrudRepository<String, Integer>) mock(CrudRepository.class);
+	}
+
+	@Test
+	void findEntityById_shouldReturnEntity_whenEntityExists() {
+		// Given
+		Integer id = 1;
+		String entity = "TestEntity";
+		when(mockRepository.findById(id)).thenReturn(Optional.of(entity));
+
+		// When
+		String result = DomainMapper.findEntityById(id, mockRepository, "TestEntity");
+
+		// Then
+		assertThat(result).isEqualTo(entity);
+	}
+
+	@Test
+	void findEntityById_shouldThrowException_whenEntityNotFound() {
+		// Given
+		Integer id = 999;
+		when(mockRepository.findById(id)).thenReturn(Optional.empty());
+
+		// When & Then
+		assertThatThrownBy(() -> DomainMapper.findEntityById(id, mockRepository, "TestEntity"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("TestEntity not found with id: 999")
+			.hasMessageContaining("Please ensure the ID is correct")
+			.hasMessageContaining("and the testentity exists in the database");
+	}
+
+	@Test
+	void findEntityByIdSimple_shouldReturnEntity_whenEntityExists() {
+		// Given
+		Integer id = 1;
+		String entity = "TestEntity";
+		when(mockRepository.findById(id)).thenReturn(Optional.of(entity));
+
+		// When
+		String result = DomainMapper.findEntityByIdSimple(id, mockRepository, "TestEntity");
+
+		// Then
+		assertThat(result).isEqualTo(entity);
+	}
+
+	@Test
+	void findEntityByIdSimple_shouldThrowException_whenEntityNotFound() {
+		// Given
+		Integer id = 999;
+		when(mockRepository.findById(id)).thenReturn(Optional.empty());
+
+		// When & Then
+		assertThatThrownBy(() -> DomainMapper.findEntityByIdSimple(id, mockRepository, "TestEntity"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("TestEntity not found with id: 999")
+			.hasMessageContaining("Please ensure the ID is correct");
+	}
+
+	@Test
+	void addPaginationModel_shouldAddAttributesToModel() {
+		// Given
+		int page = 2;
+		List<String> content = Arrays.asList("Entity1", "Entity2", "Entity3");
+		Page<String> paginatedData = new PageImpl<>(content);
+		Model model = new ExtendedModelMap();
+
+		// When
+		String result = DomainMapper.addPaginationModel(page, model, paginatedData, "listEntities",
+				"entities/entityList");
+
+		// Then
+		assertThat(result).isEqualTo("entities/entityList");
+		assertThat(model.getAttribute("currentPage")).isEqualTo(2);
+		assertThat(model.getAttribute("totalPages")).isEqualTo(1);
+		assertThat(model.getAttribute("totalItems")).isEqualTo(3L);
+		assertThat(model.getAttribute("listEntities")).isEqualTo(content);
+	}
+
+	@Test
+	void addPaginationModel_shouldHandleEmptyPage() {
+		// Given
+		int page = 1;
+		Page<String> emptyPage = new PageImpl<>(Arrays.asList());
+		Model model = new ExtendedModelMap();
+
+		// When
+		String result = DomainMapper.addPaginationModel(page, model, emptyPage, "listEntities", "entities/entityList");
+
+		// Then
+		assertThat(result).isEqualTo("entities/entityList");
+		assertThat(model.getAttribute("currentPage")).isEqualTo(1);
+		assertThat(model.getAttribute("totalPages")).isEqualTo(1);
+		assertThat(model.getAttribute("totalItems")).isEqualTo(0L);
+		assertThat(model.getAttribute("listEntities")).asList().isEmpty();
+	}
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/vet/VetControllerTests.java
@@ -54,6 +54,9 @@ class VetControllerTests {
 	@MockitoBean
 	private VetRepository vets;
 
+	@MockitoBean
+	private SpecialtyRepository specialties;
+
 	private Vet james() {
 		Vet james = new Vet();
 		james.setFirstName("James");


### PR DESCRIPTION
Extract shared entity-mapping and pagination logic into a new `DomainMapper` utility to reduce code duplication and improve maintainability across controllers.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4cc45cd-66b7-44c1-8da2-c703b8cf865f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4cc45cd-66b7-44c1-8da2-c703b8cf865f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

